### PR TITLE
Add aerawrarewar user flow integration tests

### DIFF
--- a/flows/aerawrarewarFlow.js
+++ b/flows/aerawrarewarFlow.js
@@ -1,0 +1,38 @@
+const {
+  reverseString,
+  isPalindrome,
+  countVowels,
+  capitalizeWords,
+} = require('../stringUtils');
+
+const FLOW_ID = 'aerawrarewar';
+
+function assertRunnableInput(input) {
+  if (typeof input !== 'string') {
+    throw new TypeError('Input must be a string');
+  }
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Input cannot be empty');
+  }
+  return trimmed;
+}
+
+function runAerawrarewarFlow(rawInput) {
+  const input = assertRunnableInput(rawInput);
+  const reversed = reverseString(input);
+  const palindrome = isPalindrome(input);
+  const vowels = countVowels(input);
+  const displayTitle = capitalizeWords(input);
+
+  return {
+    flowId: FLOW_ID,
+    input,
+    reversed,
+    palindrome,
+    vowels,
+    displayTitle,
+  };
+}
+
+module.exports = { FLOW_ID, runAerawrarewarFlow, assertRunnableInput };

--- a/stringUtils.js
+++ b/stringUtils.js
@@ -5,7 +5,7 @@
  */
 function reverseString(str) {
   let reversed = '';
-  for (let i = str.length; i >= 0; i--) {  
+  for (let i = str.length - 1; i >= 0; i--) {
     reversed += str[i];
   }
   return reversed;

--- a/tests/aerawrarewar.integration.test.js
+++ b/tests/aerawrarewar.integration.test.js
@@ -1,0 +1,88 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { FLOW_ID, runAerawrarewarFlow } = require('../flows/aerawrarewarFlow');
+
+test('aerawrarewar flow: happy path for canonical sample', () => {
+  const sample = 'aerawrarewar';
+  const result = runAerawrarewarFlow(sample);
+
+  assert.equal(result.flowId, FLOW_ID);
+  assert.equal(result.flowId, 'aerawrarewar');
+  assert.equal(result.input, 'aerawrarewar');
+  assert.equal(result.reversed, 'rawerarwarea');
+  assert.equal(result.palindrome, false);
+  assert.equal(result.vowels, 6);
+  assert.equal(result.displayTitle, 'Aerawrarewar');
+});
+
+test('aerawrarewar flow: happy path trims surrounding whitespace', () => {
+  const result = runAerawrarewarFlow('  aerawrarewar  ');
+
+  assert.equal(result.input, 'aerawrarewar');
+  assert.equal(result.vowels, 6);
+});
+
+test('aerawrarewar flow: happy path handles multi-word phrase for display title', () => {
+  const result = runAerawrarewarFlow('aerawrarewar flow demo');
+
+  assert.equal(result.input, 'aerawrarewar flow demo');
+  assert.equal(result.displayTitle, 'Aerawrarewar Flow Demo');
+  assert.equal(result.palindrome, false);
+});
+
+test('aerawrarewar flow: happy path palindrome with punctuation ignored', () => {
+  const result = runAerawrarewarFlow('Race car!');
+
+  assert.equal(result.palindrome, true);
+  assert.equal(result.vowels, 3);
+});
+
+test('aerawrarewar flow: error when input is not a string', () => {
+  assert.throws(() => runAerawrarewarFlow(null), TypeError);
+  assert.throws(() => runAerawrarewarFlow(undefined), TypeError);
+  assert.throws(() => runAerawrarewarFlow(42), TypeError);
+  assert.throws(() => runAerawrarewarFlow({ text: 'a' }), TypeError);
+});
+
+test('aerawrarewar flow: error when input is empty or whitespace only', () => {
+  assert.throws(() => runAerawrarewarFlow(''), (err) => {
+    assert.equal(err.message, 'Input cannot be empty');
+    return true;
+  });
+  assert.throws(() => runAerawrarewarFlow('   \t\n  '), (err) => {
+    assert.equal(err.message, 'Input cannot be empty');
+    return true;
+  });
+});
+
+test('aerawrarewar flow: edge case single character', () => {
+  const result = runAerawrarewarFlow('a');
+
+  assert.equal(result.reversed, 'a');
+  assert.equal(result.palindrome, true);
+  assert.equal(result.vowels, 1);
+  assert.equal(result.displayTitle, 'A');
+});
+
+test('aerawrarewar flow: edge case unicode letters preserved in reversal', () => {
+  const result = runAerawrarewarFlow('café');
+
+  assert.equal(result.reversed, 'éfac');
+  assert.equal(result.vowels, 1);
+});
+
+test('aerawrarewar flow: edge case mixed casing does not change palindrome outcome', () => {
+  const lower = runAerawrarewarFlow('aerawrarewar');
+  const mixed = runAerawrarewarFlow('AeRaWrArEwAr');
+
+  assert.equal(mixed.input, 'AeRaWrArEwAr');
+  assert.equal(mixed.palindrome, lower.palindrome);
+  assert.equal(mixed.vowels, lower.vowels);
+});
+
+test('aerawrarewar flow: edge case digits only are palindrome with zero vowels', () => {
+  const result = runAerawrarewarFlow('12321');
+
+  assert.equal(result.palindrome, true);
+  assert.equal(result.vowels, 0);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change introduces an explicit **aerawrarewar** user-flow entry point that composes existing `stringUtils` behavior, and adds **Node.js built-in** integration tests (`node:test`) covering happy path, validation errors, and edge cases.

## Changes

- **`flows/aerawrarewarFlow.js`**: `runAerawrarewarFlow` trims input, validates type/non-empty, then returns reversed string, palindrome flag, vowel count, and title-cased display string.
- **`tests/aerawrarewar.integration.test.js`**: Integration tests that exercise the flow end-to-end (including error paths).
- **`stringUtils.js`**: Fix `reverseString` loop bounds so reversal and palindrome checks behave correctly (required for meaningful integration coverage).

## How to run

```bash
node --test tests/aerawrarewar.integration.test.js
```

## Notes

The repository had no prior test harness; tests follow Node’s documented test runner pattern (`node:test` + `node:assert/strict`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51346641-a7bb-4034-8f9b-aaaad583733d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51346641-a7bb-4034-8f9b-aaaad583733d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

