### PR TITLE
Tetris: design-phase UI scaffold and tokens

### DIFF
--- a/css/tetris-layout.css
+++ b/css/tetris-layout.css
@@ -1,0 +1,118 @@
+@import "./tokens.css";
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-family);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-normal);
+  color: var(--color-text);
+  background: var(--color-bg);
+}
+
+.tetris-shell {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.tetris-shell__header {
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: var(--space-4);
+}
+
+.tetris-shell__title {
+  margin: 0;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.02em;
+}
+
+.tetris-shell__subtitle {
+  margin: var(--space-2) 0 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.tetris-shell__body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-6);
+  align-items: flex-start;
+}
+
+.tetris-board-wrap {
+  flex: 0 0 auto;
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-panel);
+}
+
+.tetris-board-wrap canvas {
+  display: block;
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+}
+
+.tetris-aside {
+  flex: 1 1 200px;
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.tetris-panel {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-panel);
+}
+
+.tetris-panel__label {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+
+.tetris-panel__value {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-accent);
+}
+
+.tetris-preview {
+  aspect-ratio: 1;
+  max-width: 120px;
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
+  border: 1px dashed var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.tetris-shell__footer {
+  margin-top: auto;
+  padding-top: var(--space-4);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,0 +1,31 @@
+:root {
+  --color-bg: #0f1419;
+  --color-surface: #1a2332;
+  --color-surface-elevated: #243044;
+  --color-border: #334155;
+  --color-text: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --color-accent: #38bdf8;
+  --color-accent-muted: #0ea5e9;
+
+  --font-family: system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, sans-serif;
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.25rem;
+  --font-size-xl: 1.5rem;
+  --font-weight-normal: 400;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --shadow-panel: 0 4px 24px rgba(0, 0, 0, 0.35);
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tetris</title>
+    <link rel="stylesheet" href="./css/tetris-layout.css" />
+  </head>
+  <body>
+    <div id="tetris-root"></div>
+    <script type="module" src="./js/tetris/main.js"></script>
+  </body>
+</html>

--- a/js/tetris/components/GameBoard.js
+++ b/js/tetris/components/GameBoard.js
@@ -1,0 +1,66 @@
+const DEFAULT_COLS = 10;
+const DEFAULT_ROWS = 20;
+const CELL = 24;
+
+export class GameBoard {
+  /**
+   * @param {HTMLElement} parent
+   * @param {{ cols?: number; rows?: number; cellSize?: number }} [options]
+   */
+  constructor(parent, options = {}) {
+    this.parent = parent;
+    this.cols = options.cols ?? DEFAULT_COLS;
+    this.rows = options.rows ?? DEFAULT_ROWS;
+    this.cellSize = options.cellSize ?? CELL;
+    this.canvas = null;
+  }
+
+  mount() {
+    const wrap = document.createElement("div");
+    wrap.className = "tetris-board-wrap";
+
+    const canvas = document.createElement("canvas");
+    canvas.width = this.cols * this.cellSize;
+    canvas.height = this.rows * this.cellSize;
+    canvas.setAttribute("role", "img");
+    canvas.setAttribute("aria-label", "Tetris playfield");
+
+    wrap.appendChild(canvas);
+    this.parent.appendChild(wrap);
+    this.canvas = canvas;
+    this.drawPlaceholderGrid();
+    return this;
+  }
+
+  drawPlaceholderGrid() {
+    if (!this.canvas) return;
+    const ctx = this.canvas.getContext("2d");
+    if (!ctx) return;
+
+    const w = this.canvas.width;
+    const h = this.canvas.height;
+    const cs = this.cellSize;
+
+    ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--color-bg").trim() || "#0f1419";
+    ctx.fillRect(0, 0, w, h);
+
+    ctx.strokeStyle = "rgba(148, 163, 184, 0.15)";
+    ctx.lineWidth = 1;
+    for (let x = 0; x <= this.cols; x++) {
+      ctx.beginPath();
+      ctx.moveTo(x * cs, 0);
+      ctx.lineTo(x * cs, h);
+      ctx.stroke();
+    }
+    for (let y = 0; y <= this.rows; y++) {
+      ctx.beginPath();
+      ctx.moveTo(0, y * cs);
+      ctx.lineTo(w, y * cs);
+      ctx.stroke();
+    }
+  }
+
+  getContext2D() {
+    return this.canvas ? this.canvas.getContext("2d") : null;
+  }
+}

--- a/js/tetris/components/PreviewPanel.js
+++ b/js/tetris/components/PreviewPanel.js
@@ -1,0 +1,38 @@
+export class PreviewPanel {
+  /**
+   * @param {HTMLElement} parent
+   * @param {{ title: string; placeholder?: string }} options
+   */
+  constructor(parent, options) {
+    this.parent = parent;
+    this.options = options;
+    this.root = null;
+  }
+
+  mount() {
+    const section = document.createElement("section");
+    section.className = "tetris-panel";
+
+    const label = document.createElement("h2");
+    label.className = "tetris-panel__label";
+    label.textContent = this.options.title;
+
+    const preview = document.createElement("div");
+    preview.className = "tetris-preview";
+    preview.setAttribute("aria-label", this.options.title);
+    preview.textContent = this.options.placeholder ?? "—";
+
+    section.appendChild(label);
+    section.appendChild(preview);
+    this.parent.appendChild(section);
+    this.root = section;
+    this.previewEl = preview;
+    return this;
+  }
+
+  setPlaceholder(text) {
+    if (this.previewEl) {
+      this.previewEl.textContent = text;
+    }
+  }
+}

--- a/js/tetris/components/StatPanel.js
+++ b/js/tetris/components/StatPanel.js
@@ -1,0 +1,36 @@
+export class StatPanel {
+  /**
+   * @param {HTMLElement} parent
+   * @param {{ label: string; initialValue?: string }} options
+   */
+  constructor(parent, options) {
+    this.parent = parent;
+    this.options = options;
+    this.valueEl = null;
+  }
+
+  mount() {
+    const section = document.createElement("section");
+    section.className = "tetris-panel";
+
+    const label = document.createElement("h2");
+    label.className = "tetris-panel__label";
+    label.textContent = this.options.label;
+
+    const value = document.createElement("p");
+    value.className = "tetris-panel__value";
+    value.textContent = this.options.initialValue ?? "0";
+
+    section.appendChild(label);
+    section.appendChild(value);
+    this.parent.appendChild(section);
+    this.valueEl = value;
+    return this;
+  }
+
+  setValue(text) {
+    if (this.valueEl) {
+      this.valueEl.textContent = text;
+    }
+  }
+}

--- a/js/tetris/components/TetrisApp.js
+++ b/js/tetris/components/TetrisApp.js
@@ -1,0 +1,71 @@
+import { GameBoard } from "./GameBoard.js";
+import { PreviewPanel } from "./PreviewPanel.js";
+import { StatPanel } from "./StatPanel.js";
+
+export class TetrisApp {
+  /**
+   * @param {HTMLElement} root
+   */
+  constructor(root) {
+    this.root = root;
+    this.panels = {};
+  }
+
+  mount() {
+    this.root.className = "tetris-shell";
+    this.root.innerHTML = "";
+
+    const header = document.createElement("header");
+    header.className = "tetris-shell__header";
+
+    const title = document.createElement("h1");
+    title.className = "tetris-shell__title";
+    title.textContent = "Tetris";
+
+    const subtitle = document.createElement("p");
+    subtitle.className = "tetris-shell__subtitle";
+    subtitle.textContent = "UI shell — game logic hooks in next phase.";
+
+    header.appendChild(title);
+    header.appendChild(subtitle);
+
+    const body = document.createElement("div");
+    body.className = "tetris-shell__body";
+
+    const main = document.createElement("main");
+    main.setAttribute("aria-label", "Playfield");
+
+    const board = new GameBoard(main);
+    board.mount();
+
+    const aside = document.createElement("aside");
+    aside.className = "tetris-aside";
+    aside.setAttribute("aria-label", "Game status");
+
+    const score = new StatPanel(aside, { label: "Score", initialValue: "0" });
+    const level = new StatPanel(aside, { label: "Level", initialValue: "1" });
+    const lines = new StatPanel(aside, { label: "Lines", initialValue: "0" });
+    score.mount();
+    level.mount();
+    lines.mount();
+
+    const hold = new PreviewPanel(aside, { title: "Hold", placeholder: "Empty" });
+    const next = new PreviewPanel(aside, { title: "Next", placeholder: "—" });
+    hold.mount();
+    next.mount();
+
+    body.appendChild(main);
+    body.appendChild(aside);
+
+    const footer = document.createElement("footer");
+    footer.className = "tetris-shell__footer";
+    footer.textContent = "Arrow keys: movement (wired in gameplay phase).";
+
+    this.root.appendChild(header);
+    this.root.appendChild(body);
+    this.root.appendChild(footer);
+
+    this.panels = { score, level, lines, hold, next, board };
+    return this;
+  }
+}

--- a/js/tetris/main.js
+++ b/js/tetris/main.js
@@ -1,0 +1,16 @@
+import { TetrisApp } from "./components/TetrisApp.js";
+
+function bootstrap() {
+  const root = document.getElementById("tetris-root");
+  if (!root) {
+    return;
+  }
+  const app = new TetrisApp(root);
+  app.mount();
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", bootstrap);
+} else {
+  bootstrap();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The repository had no prior frontend (utilities only). This change introduces a **vanilla HTML/CSS/JS** shell aligned with common design-system practice: **CSS custom properties as tokens**, **BEM-style layout class names**, and **small ES module “components”** that mirror component boundaries for a future implementation phase.

## Design tokens (`css/tokens.css`)

- Color roles: background, surface, border, text, muted text, accent
- Typography scale and weights
- Spacing and radii
- Panel shadow

## UI structure

- `index.html` — single mount point `#tetris-root`, module entry `js/tetris/main.js`
- `TetrisApp` — shell layout: header, main (board), aside (stats + previews), footer
- `GameBoard` — canvas placeholder with grid (engine will draw here later)
- `StatPanel` / `PreviewPanel` — reusable aside panels (score, level, lines, hold, next)

## How to preview

Serve the repo root over HTTP (ES modules require a server), e.g. `npx serve .` and open `/index.html`.

## Next phase

Wire input loop, piece state, and render callbacks into `GameBoard` / panel `setValue` APIs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d1a6d07-c42b-4e2d-8215-a1de8bf5a783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d1a6d07-c42b-4e2d-8215-a1de8bf5a783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

